### PR TITLE
SetupWizard: fix Vision Settings crash

### DIFF
--- a/src/com/android/settings/accessibility/AccessibilitySettingsForSetupWizard.java
+++ b/src/com/android/settings/accessibility/AccessibilitySettingsForSetupWizard.java
@@ -117,30 +117,30 @@ public class AccessibilitySettingsForSetupWizard extends SettingsPreferenceFragm
         // Find a screen reader.
         AccessibilityServiceInfo info = findFirstServiceWithSpokenFeedback();
         if (info == null) {
-            mScreenReaderPreference.setEnabled(false);
+            getPreferenceScreen().removePreference(mScreenReaderPreference);
         } else {
             mScreenReaderPreference.setEnabled(true);
+
+            ServiceInfo serviceInfo = info.getResolveInfo().serviceInfo;
+            String title = info.getResolveInfo().loadLabel(getPackageManager()).toString();
+            mScreenReaderPreference.setTitle(title);
+
+            ComponentName componentName = new ComponentName(serviceInfo.packageName, serviceInfo.name);
+            mScreenReaderPreference.setKey(componentName.flattenToString());
+
+            // Update the extras.
+            Bundle extras = mScreenReaderPreference.getExtras();
+            extras.putParcelable(AccessibilitySettings.EXTRA_COMPONENT_NAME, componentName);
+
+            extras.putString(AccessibilitySettings.EXTRA_PREFERENCE_KEY,
+                    mScreenReaderPreference.getKey());
+            extras.putString(AccessibilitySettings.EXTRA_TITLE, title);
+
+            String description = info.loadDescription(getPackageManager());
+            if (TextUtils.isEmpty(description)) {
+                description = getString(R.string.accessibility_service_default_description);
+            }
+            extras.putString(AccessibilitySettings.EXTRA_SUMMARY, description);
         }
-
-        ServiceInfo serviceInfo = info.getResolveInfo().serviceInfo;
-        String title = info.getResolveInfo().loadLabel(getPackageManager()).toString();
-        mScreenReaderPreference.setTitle(title);
-
-        ComponentName componentName = new ComponentName(serviceInfo.packageName, serviceInfo.name);
-        mScreenReaderPreference.setKey(componentName.flattenToString());
-
-        // Update the extras.
-        Bundle extras = mScreenReaderPreference.getExtras();
-        extras.putParcelable(AccessibilitySettings.EXTRA_COMPONENT_NAME, componentName);
-
-        extras.putString(AccessibilitySettings.EXTRA_PREFERENCE_KEY,
-                mScreenReaderPreference.getKey());
-        extras.putString(AccessibilitySettings.EXTRA_TITLE, title);
-
-        String description = info.loadDescription(getPackageManager());
-        if (TextUtils.isEmpty(description)) {
-            description = getString(R.string.accessibility_service_default_description);
-        }
-        extras.putString(AccessibilitySettings.EXTRA_SUMMARY, description);
     }
 }


### PR DESCRIPTION
Google's SetupWizard assumes that there is always going to be a Talbback/ScreenReader package in the ROM.
This isn't the case with many GApps packages, so Vision Settings FC.

Also, by looking at the code, it feels like they had actually thought about this case, and they decided to use a null check.
It was left unfinished though, because the same null value is getting used outside the null check (hence the FC).

This commit fixes it by removing the preference if a package doesn't exist, and properly applying the null check.
Or you can bundle Google Talkback in every GApps package.